### PR TITLE
create buffer if not already open

### DIFF
--- a/lua/telescope/_extensions/lspmark.lua
+++ b/lua/telescope/_extensions/lspmark.lua
@@ -120,7 +120,7 @@ function M.lspmark(opts)
 			actions.select_default:replace(function()
 				local selection = action_state.get_selected_entry()
 				actions.close(prompt_bufnr)
-				vim.api.nvim_set_current_buf(vim.fn.bufnr(selection.filename))
+				vim.api.nvim_set_current_buf(vim.fn.bufnr(selection.filename, true))
 				vim.api.nvim_win_set_cursor(0, { selection.lnum, selection.col - 1 })
 			end)
 


### PR DESCRIPTION
If the target file is not already opened in a buffer the value `-1` will be returned by `vim.fn.bufnr`.
This will make the function `vim.api.nvim_set_current_buf` to throw an error. 

Passing `true` as the second argument for `vim.fn.bufnr` will create a new buffer for the target file if it
is not loaded yet in a buffer already.