### PR TITLE
feat: added telescope entry options

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,28 @@ vim.api.nvim_create_autocmd({ "DirChanged" }, {
 })
 ```
 
+## Configuration
+
+You can pass customized options to the `setup` function:
+
+```lua
+---@type lspmark.Options
+local opts = {
+  telescope = {
+    entry_fields = {
+      order = { "comment", "file", "kind", "symbol" },
+      max_widths = {
+        comment = 0.4,
+      },
+    },
+  },
+}
+
+require("lspmark").setup(opts)
+```
+
+Supplied options are deep-merged with the [defaults](lua/lspmark/config.lua).
+
 ## Highlights
 
 `LspMark`: The highlight group for the sign at left side.
@@ -162,4 +184,3 @@ The symbols in LSP could be considered as the basic logical element for coding. 
 [^2]: "Project-wise" means the bookmarks are organized according to the cwd (project).
 [^3]: "Persistent" means the bookmarks will be saved to file so they won't be lost when nvim is opened next time.
 [^4]: "LSP" means we store each bookmark's information associated with their LSP symbol.
-

--- a/lua/lspmark.lua
+++ b/lua/lspmark.lua
@@ -1,6 +1,8 @@
 local M = {}
 
-function M.setup()
+---@param opts? lspmark.Options
+function M.setup(opts)
+	require("lspmark.config").setup(opts)
 	require("lspmark.bookmarks").setup()
 end
 

--- a/lua/lspmark/config.lua
+++ b/lua/lspmark/config.lua
@@ -1,0 +1,141 @@
+local M = {}
+
+local valid_entry_fields = {
+	"file",
+	"kind",
+	"symbol",
+	"text",
+	"comment",
+}
+
+---@alias lspmark.TelescopeEntryField
+---| '"file"'
+---| '"kind"'
+---| '"symbol"'
+---| '"text"'
+---| '"comment"'
+
+---@class lspmark.TelescopeOptions
+---@field entry_fields? lspmark.TelescopeEntryFieldsOptions
+
+---@class lspmark.TelescopeEntryFieldsOptions
+---@field order? lspmark.TelescopeEntryField[] Display order for Telescope entry fields; omit fields to hide them.
+---@field max_widths? lspmark.TelescopeEntryFieldMaxWidths Maximum calculated width as a fraction of the Telescope results width; configured fields should sum to 1 or less.
+
+---@class lspmark.TelescopeEntryFieldMaxWidths
+---@field file? number
+---@field kind? number
+---@field symbol? number
+---@field text? number
+---@field comment? number
+
+---@class lspmark.Options
+---@field telescope? lspmark.TelescopeOptions
+
+---@type lspmark.Options
+M.defaults = {
+	telescope = {
+		entry_fields = {
+			order = { "file", "kind", "symbol", "text", "comment" },
+			max_widths = {
+				file = 0.15,
+				kind = 0.1,
+				symbol = 0.15,
+				text = 0.3,
+				comment = 0.3,
+			},
+		},
+	},
+}
+
+---@type lspmark.Options
+M.options = vim.deepcopy(M.defaults)
+
+local function fail(path, message)
+	error("lspmark: invalid setup option `" .. path .. "`: " .. message, 3)
+end
+
+local function validate_keys(tbl, path, allowed_keys)
+	vim.iter(tbl):each(function(key)
+		if not vim.tbl_contains(allowed_keys, key) then
+			fail(path .. "." .. tostring(key), "unknown option")
+		end
+	end)
+end
+
+local function validate_table(value, path)
+	if type(value) ~= "table" or vim.islist(value) then
+		fail(path, "expected a table")
+	end
+end
+
+local function validate_entry_fields_order(order)
+	if type(order) ~= "table" or not vim.islist(order) then
+		fail("telescope.entry_fields.order", "expected a list")
+	end
+
+	if #order == 0 then
+		fail("telescope.entry_fields.order", "expected at least one field")
+	end
+
+	local seen = {}
+	vim.iter(order):each(function(field)
+		if not vim.tbl_contains(valid_entry_fields, field) then
+			fail("telescope.entry_fields.order", "unknown field `" .. tostring(field) .. "`")
+		end
+
+		if seen[field] then
+			fail("telescope.entry_fields.order", "duplicate field `" .. field .. "`")
+		end
+
+		seen[field] = true
+	end)
+end
+
+local function validate_entry_fields_max_widths(order, max_widths)
+	validate_table(max_widths, "telescope.entry_fields.max_widths")
+	validate_keys(max_widths, "telescope.entry_fields.max_widths", valid_entry_fields)
+
+	local total = vim.iter(order):fold(0, function(acc, field)
+		local width = max_widths[field]
+
+		if type(width) ~= "number" then
+			fail("telescope.entry_fields.max_widths." .. field, "expected a number")
+		end
+
+		if width <= 0 or width > 1 then
+			fail(
+				"telescope.entry_fields.max_widths." .. field,
+				"expected a number greater than 0 and less than or equal to 1"
+			)
+		end
+
+		return acc + width
+	end)
+
+	if total > 1 then
+		fail("telescope.entry_fields.max_widths", "widths for displayed fields must sum to 1 or less")
+	end
+end
+
+local function validate_options(opts)
+	validate_table(opts, "opts")
+	validate_keys(opts, "opts", { "telescope" })
+
+	validate_table(opts.telescope, "telescope")
+	validate_keys(opts.telescope, "telescope", { "entry_fields" })
+
+	validate_table(opts.telescope.entry_fields, "telescope.entry_fields")
+	validate_keys(opts.telescope.entry_fields, "telescope.entry_fields", { "order", "max_widths" })
+
+	validate_entry_fields_order(opts.telescope.entry_fields.order)
+	validate_entry_fields_max_widths(opts.telescope.entry_fields.order, opts.telescope.entry_fields.max_widths)
+end
+
+---@param opts? lspmark.Options
+function M.setup(opts)
+	M.options = vim.tbl_deep_extend("force", vim.deepcopy(M.defaults), opts or {})
+	validate_options(M.options)
+end
+
+return M

--- a/lua/telescope/_extensions/lspmark.lua
+++ b/lua/telescope/_extensions/lspmark.lua
@@ -6,9 +6,41 @@ local finders = require("telescope.finders")
 local previewers = require("telescope.previewers")
 local sorters = require("telescope.sorters")
 local bookmarks = require("lspmark.bookmarks")
+local config = require("lspmark.config")
 local highlight = require("telescope._extensions.highlight")
 local entry_display = require("telescope.pickers.entry_display")
 local utils = require("lspmark.utils")
+
+local function get_field_width(field, widths)
+	local width = widths[field]
+	local max_width = config.options.telescope.entry_fields.max_widths[field]
+
+	return function(_, max_columns)
+		return math.min(width, math.floor(max_width * max_columns))
+	end
+end
+
+local function display_items(widths)
+	return vim.iter(config.options.telescope.entry_fields.order)
+		:map(function(field)
+			return { width = get_field_width(field, widths) }
+		end)
+		:totable()
+end
+
+local function display_values(entry, file_name)
+	return vim.iter(config.options.telescope.entry_fields.order)
+		:map(function(field)
+			if field == "file" then
+				return { file_name }
+			elseif field == "kind" then
+				return { entry.kind_str, entry.kind_hl_group }
+			else
+				return { entry[field] }
+			end
+		end)
+		:totable()
+end
 
 function M.lspmark(opts)
 	opts = opts or {}
@@ -76,13 +108,13 @@ function M.lspmark(opts)
 
 	local display = entry_display.create({
 		separator = "  ",
-		items = {
-			{ width = max_file_name_len },
-			{ width = max_kind_len },
-			{ width = 0.2 },
-			{ width = 0.3 },
-			{ remaining = true },
-		},
+		items = display_items({
+			file = max_file_name_len,
+			kind = max_kind_len,
+			symbol = max_symbol_len,
+			text = max_line_len,
+			comment = max_comment_len,
+		}),
 	})
 
 	pickers
@@ -94,13 +126,7 @@ function M.lspmark(opts)
 					local file_name = utils.get_file_name(entry.filename)
 					return {
 						display = function()
-							return display({
-								{ file_name },
-								{ entry.kind_str, entry.kind_hl_group },
-								{ entry.symbol },
-								{ entry.text },
-								{ entry.comment },
-							})
+							return display(display_values(entry, file_name))
 						end,
 						ordinal = entry.comment .. entry.text .. entry.symbol .. entry.kind_str .. file_name,
 						filename = entry.filename,


### PR DESCRIPTION
Standard telescope entry order feels awkward for my development flow as I always comment on a bookmark and primarily want to search by those comments. Therefore, proposing to add configuration for users to be able to customize their telescope entries.

Notable points:
- The default order remains unchanged.
- Omitting a field from the `order` array hides it.
- Field widths can be capped with `max_widths`.

Happy to hear your opinion and suggestions.